### PR TITLE
Replace jekyll-sitemap plugin with custom sitemap.xml template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _site
-sitemap.xml
 Gemfile.lock
 .sass-cache
 .jekyll-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "jekyll", "~> 4.2"
 gem "tzinfo"
 gem "tzinfo-data"
 gem "jekyll-feed"
-gem "jekyll-sitemap"
 gem "jekyll-seo-tag"
 gem "jekyll-paginate"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,8 +50,6 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
-    jekyll-sitemap (1.4.0)
-      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.10.2)
@@ -96,7 +94,6 @@ DEPENDENCIES
   jekyll-feed
   jekyll-paginate
   jekyll-seo-tag
-  jekyll-sitemap
   tzinfo
   tzinfo-data
   webrick (~> 1.9)

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ highlighter:         rouge
 permalink:           /:title
 plugins:
   - jekyll-paginate
-  - jekyll-sitemap
   - jekyll-feed
   - jekyll-seo-tag
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,22 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- for page in site.pages %}
+  {%- unless page.sitemap == false or page.url == "/404.html" %}
+  <url>
+    <loc>{{ page.url | absolute_url }}</loc>
+    <lastmod>{{ page.date | default: site.time | date_to_xmlschema }}</lastmod>
+  </url>
+  {%- endunless %}
+  {%- endfor %}
+  {%- for post in site.posts %}
+  {%- unless post.sitemap == false %}
+  <url>
+    <loc>{{ post.url | absolute_url }}</loc>
+    <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+  </url>
+  {%- endunless %}
+  {%- endfor %}
+</urlset>


### PR DESCRIPTION
## Summary
This PR replaces the `jekyll-sitemap` gem dependency with a custom `sitemap.xml` template, reducing external dependencies while maintaining sitemap functionality.

## Key Changes
- Added custom `sitemap.xml` template that generates a sitemap for all pages and posts
- Removed `jekyll-sitemap` gem from `Gemfile`
- Removed `jekyll-sitemap` plugin from `_config.yml`
- Removed `sitemap.xml` from `.gitignore` (now a source file rather than generated)

## Implementation Details
The custom sitemap template:
- Iterates through all site pages and posts to generate URL entries
- Respects `sitemap: false` front matter flag to exclude specific pages/posts
- Excludes the 404 page from the sitemap
- Uses `absolute_url` filter to generate full URLs
- Includes `lastmod` timestamps using page/post dates or site build time
- Outputs valid XML in the standard sitemap format

https://claude.ai/code/session_01ENFHAN7xFY2CTtbvAdfsMF