### PR TITLE
Downgrade Font Awesome from 7.0.1 to 6.5.2

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   {% if page.math == true %}
     <script type="text/javascript" async
       src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">


### PR DESCRIPTION
## Summary
This PR downgrades the Font Awesome icon library from version 7.0.1 to 6.5.2 in the site's head template.

## Changes
- Updated Font Awesome CDN link from version 7.0.1 to 6.5.2
  - This may be due to compatibility issues, performance concerns, or to maintain consistency with other project dependencies

## Notes
This is a minor version downgrade that should be tested to ensure all icon rendering and styling continues to work as expected across the site.

https://claude.ai/code/session_01H2ufx4vABQ5nxsKwRu87yE