### PR TITLE
デスクトップヘッダーにソーシャルアイコンを追加

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,6 +9,18 @@
           <a href="{{ item.url | prepend: '/' | relative_url }}" class="menu-link">{{ item.name }}</a>
         {% endfor %}
       </div>
+      <div class="menu-group menu-social">
+        {% for item in site.data.settings.social %}
+          <a href="{{ item.link }}" class="menu-link menu-link-icon" target="_blank" rel="noopener" aria-label="{% if item.link contains 'ko-fi.com' %}Ko-fi{% else %}{{ item.icon }}{% endif %}">
+            {% if item.link contains 'ko-fi.com' %}
+              <img src="{{ '/assets/img/kofi_symbol.svg' | relative_url }}" alt="Ko-fi" class="kofi-symbol">
+            {% else %}
+              {% assign icon_style = item.style | default: 'brands' %}
+              <i class="fa-{{ icon_style }} fa-{{ item.icon }}" aria-hidden="true"></i>
+            {% endif %}
+          </a>
+        {% endfor %}
+      </div>
     </nav>
     <div class="dropdown">
       <button class="dropbtn" type="button" aria-label="Open menu">

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -55,6 +55,13 @@
   gap: 0.2rem;
 }
 
+.menu-social {
+  gap: 0.1rem;
+  margin-left: 0.5rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--line);
+}
+
 .menu-link {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
ナビリンクの右側に縦線セパレーター付きでソーシャルアイコン（X, Bluesky,
GitHub, Last.fm, Ko-fi）を表示。モバイルでは既存のドロップダウンメニュー
内アイコンがそのまま使われる（.menu-listごと非表示になるため重複しない）。

https://claude.ai/code/session_01H2ufx4vABQ5nxsKwRu87yE