### PR TITLE
dropdown-socialをdropdown-iconsにリネーム（広告ブロッカー対策）

### DIFF
--- a/_includes/ga-events.html
+++ b/_includes/ga-events.html
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   // Social icon clicks (header & footer)
-  document.querySelectorAll(".menu-social a, .footer-social a").forEach(function (link) {
+  document.querySelectorAll(".menu-social a, .dropdown-icons a, .footer-social a").forEach(function (link) {
     link.addEventListener("click", function () {
       var location = link.closest(".footer-social") ? "footer" : "header";
       var platform = link.getAttribute("aria-label") || "unknown";

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,7 +33,7 @@
           {% endfor %}
         </div>
         <div class="dropdown-divider" aria-hidden="true"></div>
-        <div class="dropdown-section dropdown-social">
+        <div class="dropdown-section dropdown-icons">
           {% for item in site.data.settings.social %}
             <a href="{{ item.link }}" class="menu-link menu-link-icon" target="_blank" rel="noopener" aria-label="{% if item.link contains 'ko-fi.com' %}Ko-fi{% else %}{{ item.icon }}{% endif %}">
               {% if item.link contains 'ko-fi.com' %}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -182,13 +182,13 @@
     background: var(--line);
   }
 
-  .dropdown-social {
+  .dropdown-icons {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 0.45rem;
   }
 
-  .dropdown-social .menu-link-icon {
+  .dropdown-icons .menu-link-icon {
     display: flex;
     width: 100%;
     min-width: 0;
@@ -199,13 +199,13 @@
     background: var(--surface-2);
   }
 
-  .dropdown-social .menu-link-icon .fa-brands,
-  .dropdown-social .menu-link-icon .fa-solid {
+  .dropdown-icons .menu-link-icon .fa-brands,
+  .dropdown-icons .menu-link-icon .fa-solid {
     font-size: 1rem;
     line-height: 1;
   }
 
-  .dropdown-social .menu-link-icon .kofi-symbol {
+  .dropdown-icons .menu-link-icon .kofi-symbol {
     width: 1.35rem;
     height: 1.35rem;
   }


### PR DESCRIPTION
広告ブロッカーのフィルタ（[class*="social"]等）により
ドロップダウン内のSNSアイコンセクションが非表示になる問題に対応。
クラス名から"social"を除外してフィルタ回避。

https://claude.ai/code/session_01ChStKbxatx9ZwpQrorLDvq