### PR TITLE
style: gray out inactive pagination buttons

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -84,6 +84,11 @@
   color: var(--accent);
 }
 
+span.pagination-button {
+  opacity: 0.3;
+  cursor: default;
+}
+
 @media (max-width: $tablet-width) {
   .home-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Inactive pagination buttons (rendered as <span>) now have 30% opacity and default cursor to visually communicate they are non-interactive.

https://claude.ai/code/session_017zcZLF9CC6aZni43UyXTyB